### PR TITLE
Added alias name in device details api response in spec

### DIFF
--- a/spec/definitions/Device.yaml
+++ b/spec/definitions/Device.yaml
@@ -8,6 +8,9 @@ properties:
     format: url
   device_name:
     type: string
+  alias_name:
+    type: string
+    description: Device friendly name
   policy_name:
     type: string
   status:

--- a/spec/definitions/Device.yaml
+++ b/spec/definitions/Device.yaml
@@ -44,6 +44,10 @@ properties:
     items:
       type: string
       format: url
+  tags:
+    type: array
+    items:
+      type: string
   api_level:
     type: integer
     format: int32


### PR DESCRIPTION
alias_name in device details objects is a device friendly name that can be optionally set.