### PR TITLE
Change API key reference link

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -152,7 +152,7 @@ securityDefinitions:
       > Please note the use of keyword **Bearer** before the token value.
 
 
-      You can read more about api key authentication scheme [here](https://swagger.io/docs/specification/authentication/api-keys/).
+      You can read more about api key authentication scheme [here](https://console-docs.esper.io/API/generate.html).
     name: Authorization
     type: apiKey
     in: header


### PR DESCRIPTION
The (here) link under APIKey was pointing to the old docs. Changed it to link to the new API key generation page.