### PR TITLE
Fixes in application and content API spec

### DIFF
--- a/spec/paths/enterprise@{enterprise_id}@application@.yaml
+++ b/spec/paths/enterprise@{enterprise_id}@application@.yaml
@@ -19,7 +19,7 @@ get:
       in: query
       description: filter by package name (exact match)
       required: false
-      type: string
+      type: boolean
     - name: has_uploaded_version
       in: query
       description: Returns applications having atleast on version uploaded

--- a/spec/paths/enterprise@{enterprise_id}@application@{application_id}@version@{version_id}@.yaml
+++ b/spec/paths/enterprise@{enterprise_id}@application@{application_id}@version@{version_id}@.yaml
@@ -4,12 +4,7 @@ get:
   description: Returns AppVersion instance
   produces:
     - application/json
-  parameters: 
-    - name: request_id
-      in: query
-      description: If this value exists in cache, delete the application and cache entry.
-      required: false
-      type: string
+  parameters: []
   responses:
     '200':
       description: successful operation
@@ -37,7 +32,12 @@ delete:
   description: Empty response
   produces:
     - application/json
-  parameters: []
+  parameters: 
+    - name: request_id
+      in: query
+      description: If this value exists in cache, delete the application and cache entry.
+      required: false
+      type: string
   responses:
     '200':
       description: No request id is provided and the application is linked to one or more templates. Returns a request_id. Call with this request id to delete the resource.

--- a/spec/paths/v0@enterprise@{enterprise_id}@content@{content_id}@.yaml
+++ b/spec/paths/v0@enterprise@{enterprise_id}@content@{content_id}@.yaml
@@ -114,10 +114,9 @@ patch:
 parameters:
   - name: content_id
     in: path
-    description: A UUID string identifying a content instance.
+    description: An integer string identifying a content instance.
     required: true
-    type: string
-    format: uuid
+    type: integer
   - name: enterprise_id
     description: A UUID string identifying enterprise.
     in: path

--- a/spec/paths/v1@enterprise@{enterprise_id}@application@.yaml
+++ b/spec/paths/v1@enterprise@{enterprise_id}@application@.yaml
@@ -19,7 +19,7 @@ get:
       in: query
       description: filter by package name (exact match)
       required: false
-      type: string
+      type: boolean
     - name: has_uploaded_version
       in: query
       description: Returns applications having atleast on version uploaded

--- a/spec/paths/v1@enterprise@{enterprise_id}@application@upload@.yaml
+++ b/spec/paths/v1@enterprise@{enterprise_id}@application@upload@.yaml
@@ -1,0 +1,53 @@
+post:
+  operationId: upload
+  summary: Upload an application to enterprise
+  description: Returns application
+  produces:
+    - application/json
+  consumes:
+    - multipart/form-data
+    - application/x-www-form-urlencoded
+  parameters:
+    - name: app_file
+      description: Valid APK file
+      in: formData
+      required: true
+      type: file
+  responses:
+    '201':
+      description: successful operation
+      schema:
+        type: object
+        properties:
+          application:
+            $ref: '#/definitions/Application'
+    '400':
+      description: Bad request
+      schema: 
+        $ref: '#/definitions/ErrorResponse'
+    '401':
+      description: Authorization information is missing or invalid.
+      schema: 
+        $ref: '#/definitions/ErrorResponse'
+    '403':
+      description: Forbidden, no permission to perform this action.
+      schema: 
+        $ref: '#/definitions/ErrorResponse'
+    '415':
+      description: Unsupported media type.
+      schema: 
+        $ref: '#/definitions/ErrorResponse'
+    '500':
+      description: Internal server error
+      schema: 
+        $ref: '#/definitions/ErrorResponse'
+  security:
+    - apiKey: []
+  tags:
+    - Application V1
+parameters:
+  - name: enterprise_id
+    description: A UUID string identifying this enterprise.
+    in: path
+    required: true
+    type: string

--- a/spec/paths/v1@enterprise@{enterprise_id}@application@{application_id}@version@{version_id}@installdevices.yaml
+++ b/spec/paths/v1@enterprise@{enterprise_id}@application@{application_id}@version@{version_id}@installdevices.yaml
@@ -62,7 +62,7 @@ get:
   security:
     - apiKey: []
   tags:
-    - Application
+    - Application V1
 parameters:
   - name: version_id
     in: path


### PR DESCRIPTION
Fixed application and content API spec.

- Change package_name_exact to boolean.
- Removed request_id from get_app_version.
- Added request_id in delete_app_version.
- Added support for upload in ApplicationV1Api.
- Moved 'get_install_devices_v1' from ApplicationApi to ApplicationV1Api.
- Changed content_id to integer.